### PR TITLE
Reduce docker image size with Alpine Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM python:2.7
+FROM alpine:3.5
 
 MAINTAINER kfei <kfei@kfei.net>
 
-RUN pip install slack-cleaner
+RUN apk add --no-cache python2 py-pip && pip install slack-cleaner
 
 VOLUME ["/backup"]
 
 WORKDIR /backup
 
-ENTRYPOINT ["/bin/bash"]
+ENTRYPOINT ["/bin/sh"]


### PR DESCRIPTION
Python containers use debian based image. It's too large image for container. So I changed base image from python:2.7 to alpine:3.5. It can succeed reducing the image size and speeding up to pull image.

## ex

```bash
ek@xxx ~/slack-cleaner> sudo docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
slack-cleaner       alpine              9beb62557257        13 seconds ago      55.3 MB
```