### PR TITLE
Add quiet option for less verbosity

### DIFF
--- a/slack_cleaner/args.py
+++ b/slack_cleaner/args.py
@@ -71,7 +71,7 @@ class Args():
 
         self.log = args.log
         
-        self.quient = args.quiet
+        self.quiet = args.quiet
 
         self.rate_limit = args.rate
 

--- a/slack_cleaner/args.py
+++ b/slack_cleaner/args.py
@@ -14,6 +14,10 @@ class Args():
         # Log
         p.add_argument('--log', action='store_true',
                        help='Create a log file in the current directory')
+        
+        # Quiet
+        p.add_argument('--quiet', action='store_true',
+                       help='Run quietly, does not log messages deleted')
 
         # Rate limit
         p.add_argument('--rate', type=int,
@@ -66,6 +70,8 @@ class Args():
         self.token = args.token
 
         self.log = args.log
+        
+        self.quient = args.quiet
 
         self.rate_limit = args.rate
 

--- a/slack_cleaner/cli.py
+++ b/slack_cleaner/cli.py
@@ -144,7 +144,8 @@ def delete_message_on_channel(channel_id, message):
             pp.pprint(message)
             return
 
-        logger.warning(Colors.RED + 'Deleted message -> ' + Colors.ENDC
+        if not args.quiet
+            logger.warning(Colors.RED + 'Deleted message -> ' + Colors.ENDC
                        + get_user_name(message)
                        + ' : %s'
                        , message.get('text', ''))
@@ -154,7 +155,8 @@ def delete_message_on_channel(channel_id, message):
 
     # Just simulate the task
     else:
-        logger.warning(Colors.YELLOW + 'Will delete message -> ' + Colors.ENDC
+        if not args.quiet
+            logger.warning(Colors.YELLOW + 'Will delete message -> ' + Colors.ENDC
                        + get_user_name(message)
                        + ' :  %s'
                        , message.get('text', ''))
@@ -206,7 +208,8 @@ def delete_file(file):
             pp.pprint(file)
             return
 
-        logger.warning(Colors.RED + 'Deleted file -> ' + Colors.ENDC
+        if not args.quiet
+            logger.warning(Colors.RED + 'Deleted file -> ' + Colors.ENDC
                        + file.get('title', ''))
 
         if args.rate_limit:
@@ -214,7 +217,8 @@ def delete_file(file):
 
     # Just simulate the task
     else:
-        logger.warning(Colors.YELLOW + 'Will delete file -> ' + Colors.ENDC
+        if not args.quiet
+            logger.warning(Colors.YELLOW + 'Will delete file -> ' + Colors.ENDC
                        + file.get('title', ''))
 
     counter.increase()


### PR DESCRIPTION
Added option for --quiet so that all of the deleted messages/files are not directly written to the logger output. Especially helpful when trying to run in a script or cron job. 

Mentioned in Issue #40 