### PR TITLE
Clarifying where tokens can be generated

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ slack-cleaner --token <TOKEN> --file --types snippets,images
 slack-cleaner --help
 ```
 
+## Tokens
+
+You will need to generate a Slack legacy token to use slack-cleaner. You can generate a token [here](https://api.slack.com/custom-integrations/legacy-tokens):
+
+[https://api.slack.com/custom-integrations/legacy-tokens](https://api.slack.com/custom-integrations/legacy-tokens)
+
 ## Tips
 
 After the task, a backup file `slack-cleaner.<timestamp>.log` will be created


### PR DESCRIPTION
Slack have slightly hidden away the legacy token functionality so for clarity's sake I've added the relevant link to README.md to avoid any confusion.