### PR TITLE
Fixes python3 dict removal of iteritems() - is now just items()

### DIFF
--- a/slack_cleaner/cli.py
+++ b/slack_cleaner/cli.py
@@ -221,7 +221,7 @@ def delete_file(file):
 
 
 def get_user_id_by_name(name):
-    for k, v in user_dict.iteritems():
+    for k, v in user_dict.items():
         if v == name:
             return k
 


### PR DESCRIPTION
There's a bug here if using python 3 and attempting to delete specific user messages.
This is caused by a call to iteritems() which no longer exists in Python 3.x