### PR TITLE
Add regex filter for messages

### DIFF
--- a/slack_cleaner/args.py
+++ b/slack_cleaner/args.py
@@ -52,6 +52,9 @@ class Args():
         p.add_argument('--types',
                        help='Delete files of a certain type, e.g., posts,pdfs')
 
+        p.add_argument('--match',
+                       help='Only delete messages that match this regex')
+
         # Perform or not
         p.add_argument('--perform', action='store_true',
                        help='Perform the task')
@@ -82,5 +85,6 @@ class Args():
         self.start_time = args.after
         self.end_time = args.before
         self.types = args.types
+        self.match = args.match
 
         self.perform = args.perform

--- a/slack_cleaner/cli.py
+++ b/slack_cleaner/cli.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 import logging
 import pprint
+import re
 import sys
 import time
 
@@ -45,6 +46,12 @@ logger.info('Running slack-cleaner v' + __version__)
 
 # User dict
 user_dict = {}
+
+# compiled regex
+regex_match = None
+
+if args.match:
+    regex_match = re.compile(args.match)
 
 
 # Construct a local user dict for further usage
@@ -132,6 +139,10 @@ def delete_message_on_channel(channel_id, message):
             return m.get('username')
         else:
             return '_'
+
+    if args.match:
+        if not regex_match.match(message.get('text')):
+            return
 
     # Actually perform the task
     if args.perform:


### PR DESCRIPTION
This addresses the need to delete some but not all messages from a user/bot. I added in argument called `match` that represents a regex string. If defined, it will be compiled and messages that don't match will be skipped.